### PR TITLE
Fix #28

### DIFF
--- a/sqs.html
+++ b/sqs.html
@@ -52,11 +52,18 @@ Nodes to Send, Receive, Delete & Purge AWS SQS entries.
   Puts msg.payload onto the configured SQS Queue. <br/>
   Optionally: <br/>
   <ul>
-<li>
-  msg.messageAttributes
-</li>  <li>
-  msg.delaySeconds
-  </li>
+    <li>
+      msg.messageAttributes
+    </li>  
+    <li>
+      msg.delaySeconds
+    </li>
+    <li>
+      msg.messageGroupId
+    </li>
+    <li>
+      msg.messageDeduplicationId
+    </li>
   </ul>
   </br/>
 </p>

--- a/sqs.js
+++ b/sqs.js
@@ -74,6 +74,8 @@ module.exports = function(RED) {
                   };
                   if (msg.messageAttributes) params.MessageAttributes=msg.messageAttributes;
                   if (msg.delaySeconds) params.DelaySeconds=msg.delaySeconds;
+                  if (msg.messageDeduplicationId) params.MessageDeduplicationId=msg.messageDeduplicationId;
+                  if (msg.messageGroupId) params.MessageGroupId=msg.messageGroupId;			    
                   sqs.sendMessage(params, node.sendMsg);
                 break;
               case 'purge':


### PR DESCRIPTION
Fifo queues on SQS requires MessageDeduplicationId and MessageGroupId parameters.

Check [this](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html) for more information