### PR TITLE
Shouldn't kill the flow in all cases

### DIFF
--- a/Polly.js
+++ b/Polly.js
@@ -54,7 +54,7 @@ module.exports = function(RED) {
 				if (err) {
 				node.status({fill:"red",shape:"ring",text:"error"});
 				node.error("failed: " + err.toString(),msg);
-				return;
+				//return;
 				} else {
 				msg.payload = data;
 				node.status({});


### PR DESCRIPTION
I called GetObject and the key was not found. The flow terminates. That's a bit unfriendly, IMO. Perhaps some functions should terminate the flow, but I don't think things that may be dynamically set during runtime (eg filenames/Keys) should handle error states by terminating the flow.