### PR TITLE
Updated Rekogniton Concurrency Issue fix #66

### DIFF
--- a/gen_scripts/gen.js
+++ b/gen_scripts/gen.js
@@ -28,7 +28,7 @@ function serviceNameMapper(name){
 	map['Data.iot']='IotData';
 
 	return map[name] || name;
-		
+
 };
 
 function firstLetterUppercase(string) {
@@ -58,8 +58,8 @@ function getReqs(serviceDef){
 		 }
 		}).forEach(reqA=>{reqA.forEach(req=>{reqs[req]=1})});
 	console.log(JSON.stringify(reqs));
-	return (Object.keys(reqs)); 
-	} 
+	return (Object.keys(reqs));
+	}
 
 
 serviceDef.metadata.serviceName=serviceNameMapper(serviceDef.metadata.endpointPrefix);
@@ -101,7 +101,7 @@ var htmlFile=`
 		<label for="node-input-name"><i class="fa fa-tag"></i>Name</label>
 		<input type="text" id="node-input-name" placeholder="Name"></input>
 	</div>
-	<hr/>	
+	<hr/>
 	<div id="AttrHolder">
 	      ${getReqs(serviceDef).map(r=>`
 	<div class="form-row" id='${r}Attr' class='hiddenAttrs'>
@@ -220,7 +220,7 @@ module.exports = function(RED) {
 		var awsService = new AWS.${serviceDef.metadata.serviceName}( { 'region': node.region } );
 
 		node.on("input", function(msg) {
-			node.sendMsg = function (err, data) {
+			node.sendMsg = function (err, data, msg) {
 				if (err) {
 				    node.status({fill:"red",shape:"ring",text:"error"});
                     node.error("failed: " + err.toString(), msg);
@@ -232,14 +232,12 @@ module.exports = function(RED) {
 				}
 				node.send([msg,null]);
 			};
-		
-			var _cb=function(err,data){
-				node.sendMsg(err,data);
-			}		
 
 			if (typeof service[node.operation] == "function"){
 				node.status({fill:"blue",shape:"dot",text:node.operation});
-				service[node.operation](awsService,msg,_cb);
+				service[node.operation](awsService,msg,function(err,data){
+   				node.sendMsg(err, data, msg);
+   			});
 			} else {
 				node.error("failed: Operation node defined - "+node.operation);
 			}
@@ -250,7 +248,7 @@ module.exports = function(RED) {
 			outArg = (typeof outArg !== 'undefined') ? outArg : arg;
 
 			if (typeof src[arg] !== 'undefined'){
-				if (isObject && typeof src[arg]=="string" && src[arg] != "") { 
+				if (isObject && typeof src[arg]=="string" && src[arg] != "") {
 					tmpValue=JSON.parse(src[arg]);
 				}
 				out[outArg]=tmpValue;
@@ -278,7 +276,7 @@ module.exports = function(RED) {
 			svc.${firstLetterLowercase(op)}(params,cb);
 		}
 
-		`)}	
+		`)} 
 
 	}
 	RED.nodes.registerType("AWS ${serviceDef.metadata.serviceName}", AmazonAPINode);


### PR DESCRIPTION
This fixes an issue with the Rekognition node where it uses the same msg object as the base for the response message when handling multiple messages concurrently. The msg.payload object was correct, just the msg was reused.

This replaces the original pull request, and updates the build script for the same change.  The change to Rekognition has been tested and validated.

Tks